### PR TITLE
Renovate: disable dependency dashboard, add minimumReleaseAge + behind-base rebasing

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:best-practices"
   ],
+  "dependencyDashboard": false,
+  "minimumReleaseAge": "3 days",
+  "rebaseWhen": "behind-base-branch",
   "packageRules": [
     {
       "matchManagers": ["dockerfile", "docker-compose"],


### PR DESCRIPTION
Tunes `.github/renovate.json` (extends `config:best-practices`):

- **`dependencyDashboard: false`** - stops the overview issue; update PRs continue unchanged.
- **`minimumReleaseAge: "3 days"`** - hold a PR until its release has aged 3 days, avoiding bleeding-edge breakage (e.g. the phpunit 13.2.1 / paratest timing gap).
- **`rebaseWhen: "behind-base-branch"`** - auto-rebase PRs when `main` advances, keeping them up-to-date and mergeable under the new branch protection.

Config-only change. Once merged, Renovate auto-closes the existing dependency dashboard issue on its next run.