### PR TITLE
disable lockfile maintainance, since plugins have their own lockfile …

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "config:best-practices"
   ],
   "dependencyDashboard": false,
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "minimumReleaseAge": "3 days",
   "rebaseWhen": "behind-base-branch",
   "packageRules": [


### PR DESCRIPTION
…extentions that might not be cisible to the main repo